### PR TITLE
SVC_IRQn compatibility define

### DIFF
--- a/Include/stm32c0xx.h
+++ b/Include/stm32c0xx.h
@@ -193,6 +193,9 @@ typedef enum
   * @}
   */
 
+/* Aliases for IRQn_Type */
+#define SVC_IRQn              SVCall_IRQn
+
 #if defined (USE_HAL_DRIVER)
  #include "stm32c0xx_hal.h"
 #endif /* USE_HAL_DRIVER */


### PR DESCRIPTION
## Compatibility define
Added a compatibility define for SVC_IRQn to common device header. Same solution was implemented in some other ST devices like STM32G0. STM32Cube generated code (stm32c0xx_hal_msp.c) uses SVC_IRQn define, ST FW pack (v1.1.0) for STM32C0 device uses SVCall_IRQn.